### PR TITLE
Various improvements

### DIFF
--- a/Example/CachyDemo/BoardCell.swift
+++ b/Example/CachyDemo/BoardCell.swift
@@ -23,7 +23,7 @@ class BoardCell: UICollectionViewCell {
         didSet {
             if let board = board, let urls = board.urls, let thumb = urls.regular, let url = URL(string: thumb) {
                 let request = URLRequest(url: url)
-                cachy.loadWith(urlRequest: request) { [weak self] data, _ in
+                cachy.loadWithURLRequest(request) { [weak self] data, _ in
                     self?.imageView.image = UIImage(data: data, scale: 1.0)
                 }
                 // imageView.cachyImageLoad(url, isShowLoading: true, completionBlock: { _, _ in })

--- a/Example/CachyDemo/ViewController.swift
+++ b/Example/CachyDemo/ViewController.swift
@@ -35,8 +35,9 @@ class ViewController: UICollectionViewController {
     }
 
     private func fetchData(isRefresh _: Bool = false) {
-        let url = URLRequest(url: URL(string: Constant.Url.base)!)
-        cachy.loadWith(urlRequest: url) { [weak self] data, _ in
+        CachyLoaderManager.shared.configure(isOnlyInMemory: false)
+        let request = URLRequest(url: URL(string: Constant.Url.base)!)
+        cachy.loadWithURLRequest(request) { [weak self] data, _ in
             let decoder = JSONDecoder()
             do {
                 guard let self = self  else {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you want to download and cache a file(JSON, ZIP, UIImage or any type) then si
 ```swift
  let cachy = CachyLoader()
 
- cachy.load(url: URL(string: "http://your_url_here")!) { [weak self] data, _ in
+ cachy.loadWithURL(URL(string: "http://your_url_here")!) { [weak self] data, _ in
     // Do whatever you need with the data object
  }
 ```
@@ -63,8 +63,8 @@ You can also cache with **URLRequest**
 ```swift
 let cachy = CachyLoader()
 
-let url = URLRequest(url: URL(string: "http://your_url_here")!)
-cachy.loadWith(urlRequest: url) { [weak self] data, _ in
+let request = URLRequest(url: URL(string: "http://your_url_here")!)
+cachy.loadWithURLRequest(request) { [weak self] data, _ in
     // Do whatever you need with the data object
  }
 ```
@@ -77,7 +77,7 @@ let cachy = CachyLoader()
 //(optional) if isRefresh = true it will forcefully refresh data from remote server
 //(optional) you can set **expirationDate** according to your need
 
-cachy.load(url: URL(string: "http://your_url_here")!,isRefresh = false,expirationDate = ExpiryDate.everyDay.expiryDate()) { [weak self] data, _ in
+cachy.loadWithURL(URL(string: "http://your_url_here")!,isRefresh = false,expirationDate = ExpiryDate.everyDay.expiryDate()) { [weak self] data, _ in
      // Do whatever you need with the data object
   }
 ```
@@ -99,13 +99,15 @@ It will download, cache and load UIImage into your UIImageView
 // Here if you want set how much much memory/disk should use set memoryCapacity, diskCapacity
 // To cache only on memory set isOnlyInMemory which is true by default
 // You may set expiry date for all the cache object by setting expiryDate
+// Your objects may not be conforming to `NSSecureCoding`, set this variable to `false`
 
 CachyLoaderManager.shared.configure(
      memoryCapacity: 1020,
      maxConcurrentOperationCount: 10,
      timeoutIntervalForRequest: 3,
      expiryDate: ExpiryDate.everyWeek,
-     isOnlyInMemory: true
+     isOnlyInMemory: true,
+     isSupportingSecureCodingSaving: false
 )
 ```
 

--- a/Sources/Cachy/Cachy.swift
+++ b/Sources/Cachy/Cachy.swift
@@ -71,7 +71,11 @@ public class Cachy: NSCache<AnyObject, AnyObject> {
     /// Static property to store the cost limit of the cache (by default it is 0)
     public static var totalCostLimit = 0
 
+    /// Caching only on memory, otherwise will try to cache to Disk too
     public static var isOnlyInMemory = true
+    
+    /// For those objects not conforming to `NSSecureCoding`, set this variable to `false`
+    public static var isSupportingSecureCodingSaving = true
 
     // MARK: - Public properties
 
@@ -269,9 +273,8 @@ public class Cachy: NSCache<AnyObject, AnyObject> {
             if !fileManager.fileExists(atPath: fileName.absoluteString) || object.isUpdated {
                 //  let data = NSKeyedArchiver.archivedData(withRootObject: object)
                 //  try? data.write(to: fileName)
-
                 if #available(iOS 11.0, *) {
-                    let data = try? NSKeyedArchiver.archivedData(withRootObject: object, requiringSecureCoding: true)
+                    let data = try? NSKeyedArchiver.archivedData(withRootObject: object, requiringSecureCoding: Cachy.isSupportingSecureCodingSaving)
                     try? data?.write(to: fileName)
                 } else {
                     let data = try? NSKeyedArchiver.archivedData(withRootObject: object)

--- a/Sources/Cachy/CachyLoader.swift
+++ b/Sources/Cachy/CachyLoader.swift
@@ -33,10 +33,13 @@ open class CachyLoaderManager {
                           maxConcurrentOperationCount: Int = 10,
                           timeoutIntervalForRequest: Double = 3,
                           expiryDate: ExpiryDate = .everyWeek,
-                          isOnlyInMemory: Bool = true) {
+                          isOnlyInMemory: Bool = true,
+                          isSupportingSecureCodingSaving: Bool = true) {
         cache.totalCostLimit = memoryCapacity
         cache.expiration = expiryDate
+        
         Cachy.isOnlyInMemory = isOnlyInMemory
+        Cachy.isSupportingSecureCodingSaving = isSupportingSecureCodingSaving
         
         sessionQueue = OperationQueue()
         sessionQueue.maxConcurrentOperationCount = maxConcurrentOperationCount

--- a/Sources/Cachy/CachyLoader.swift
+++ b/Sources/Cachy/CachyLoader.swift
@@ -29,7 +29,7 @@ open class CachyLoaderManager {
         self.sessionConfiguration, delegate: nil,
                                                                   delegateQueue: self.sessionQueue)
 
-    func configure(memoryCapacity: Int = 30 * 1024 * 1024,
+    public func configure(memoryCapacity: Int = 30 * 1024 * 1024,
                    maxConcurrentOperationCount: Int = 10,
                    timeoutIntervalForRequest: Double = 3,
                    expiryDate: ExpiryDate = .everyWeek,

--- a/Sources/Cachy/CachyUIImage.swift
+++ b/Sources/Cachy/CachyUIImage.swift
@@ -78,7 +78,7 @@ public extension UIImageView {
             showLoading()
         }
         let loader = CachyLoader()
-        loader.load(url: url) { [weak self] data, url in
+        loader.loadWithURL(url) { [weak self] data, url in
             if isShowLoading {
                 self?.hideLoading()
             }


### PR DESCRIPTION
CachyKit will now support:

- `URLRequest` with additional headers and other settings. Previously was only referring to a new `URLRequest` created inside the `load` method getting its `url` even though the `load` method was accepting a `urlRequest` as a parameter.
- Archiving now works correctly after supporting optional secure coding for disk saving
- `configure` method is now accessible outside of the CachyKit pod and is now matching the documentation
- Code documentation improved
- Readme updated